### PR TITLE
feat(completed): 完了カードに完了日時フッターを追加

### DIFF
--- a/apps/web/src/actions/cards.ts
+++ b/apps/web/src/actions/cards.ts
@@ -384,8 +384,7 @@ export async function resetCardToUnlearned(id: string): Promise<Card> {
 
 /**
  * 完了タブに表示するカードを取得
- * 1. status = 'completed' のカード（復習完了済み）
- * 2. 今日復習したカード（study_logsで今日評価を受けたカード）
+ * status = 'completed' のカードのみ（completed_at 降順）
  */
 export async function getTodayCompletedCards(): Promise<CardWithTags[]> {
   const supabase = await createClient();
@@ -395,72 +394,23 @@ export async function getTodayCompletedCards(): Promise<CardWithTags[]> {
     throw new Error('Unauthorized');
   }
 
-  // 今日の開始時刻（00:00:00）
-  const todayStart = new Date();
-  todayStart.setHours(0, 0, 0, 0);
+  const { data, error } = await supabase
+    .from('cards')
+    .select(`
+      *,
+      card_tags (
+        tag:tags (*)
+      )
+    `)
+    .eq('user_id', user.id)
+    .eq('status', 'completed')
+    .order('completed_at', { ascending: false });
 
-  // 並列で取得: 1. status='completed'のカード 2. 今日評価を受けたカードID
-  const [completedCardsResult, studyLogsResult] = await Promise.all([
-    supabase
-      .from('cards')
-      .select(`
-        *,
-        card_tags (
-          tag:tags (*)
-        )
-      `)
-      .eq('user_id', user.id)
-      .eq('status', 'completed')
-      .order('completed_at', { ascending: false }),
-    supabase
-      .from('study_logs')
-      .select('card_id')
-      .eq('user_id', user.id)
-      .gte('studied_at', todayStart.toISOString()),
-  ]);
-
-  if (completedCardsResult.error) {
-    throw new Error(`Failed to fetch completed cards: ${completedCardsResult.error.message}`);
+  if (error) {
+    throw new Error(`Failed to fetch completed cards: ${error.message}`);
   }
 
-  if (studyLogsResult.error) {
-    throw new Error(`Failed to fetch study logs: ${studyLogsResult.error.message}`);
-  }
-
-  const completedCards = completedCardsResult.data || [];
-  const studyLogs = studyLogsResult.data || [];
-
-  // 今日復習したカードIDを取得（重複除去）
-  const todayStudiedCardIds = [...new Set(studyLogs.map(log => log.card_id))];
-
-  // completedCardsのIDセット（重複チェック用）
-  const completedCardIds = new Set(completedCards.map(card => card.id));
-
-  // 今日復習したがstatus='completed'ではないカードを取得
-  const additionalCardIds = todayStudiedCardIds.filter(id => !completedCardIds.has(id));
-
-  let additionalCards: SupabaseCardRow[] = [];
-  if (additionalCardIds.length > 0) {
-    const { data, error } = await supabase
-      .from('cards')
-      .select(`
-        *,
-        card_tags (
-          tag:tags (*)
-        )
-      `)
-      .eq('user_id', user.id)
-      .in('id', additionalCardIds);
-
-    if (error) {
-      throw new Error(`Failed to fetch additional cards: ${error.message}`);
-    }
-    additionalCards = (data || []) as unknown as SupabaseCardRow[];
-  }
-
-  const allCards = [...completedCards, ...additionalCards];
-
-  return (allCards as unknown as SupabaseCardRow[]).map(mapCardRow);
+  return ((data || []) as unknown as SupabaseCardRow[]).map(mapCardRow);
 }
 
 /**

--- a/apps/web/src/app/(main)/cards/completed/__tests__/page.test.tsx
+++ b/apps/web/src/app/(main)/cards/completed/__tests__/page.test.tsx
@@ -11,8 +11,8 @@ vi.mock('@/hooks/useCards', () => ({
 }));
 
 vi.mock('@/components/home', () => ({
-  CardList: ({ cards }: { cards: CardWithTags[] }) => (
-    <div data-testid="card-list">{cards.length} cards</div>
+  CompletedCard: ({ card }: { card: CardWithTags }) => (
+    <div data-testid="completed-card">{card.id}</div>
   ),
 }));
 
@@ -50,7 +50,7 @@ function createCard(overrides: Partial<CardWithTags> = {}): CardWithTags {
     currentStep: 0,
     nextReviewAt: null,
     status: 'completed',
-    completedAt: '2025-01-01T00:00:00Z',
+    completedAt: '2026-04-02T10:00:00Z',
     createdAt: '2025-01-01T00:00:00Z',
     updatedAt: '2025-01-01T00:00:00Z',
     tags: [],
@@ -81,7 +81,7 @@ describe('CompletedCardsPage', () => {
   });
 
   it('ページヘッダーに「完了」タイトルが表示される', async () => {
-    // Given: データ読み込み完了（完了カードなし）
+    // Given: データ読み込み完了
     mockUseTodayCompletedCards.mockReturnValue({
       data: [],
       isLoading: false,
@@ -126,8 +126,27 @@ describe('CompletedCardsPage', () => {
     });
   });
 
+  it('完了カードがある場合: CompletedCardが件数分表示される', async () => {
+    // Given: 完了カード2件
+    const card1 = createCard({ id: 'c1' });
+    const card2 = createCard({ id: 'c2' });
+    mockUseTodayCompletedCards.mockReturnValue({
+      data: [card1, card2],
+      isLoading: false,
+    });
+
+    // When: ページをレンダリング
+    await renderPage();
+
+    // Then: 完了カード2件表示される
+    await waitFor(() => {
+      expect(screen.getAllByTestId('completed-card')).toHaveLength(2);
+      expect(screen.getByTestId('card-list')).toBeInTheDocument();
+    });
+  });
+
   it('dataがundefinedの場合: 空状態が表示される', async () => {
-    // Given: データがundefined（初期状態）
+    // Given: dataがundefined（初期状態）
     mockUseTodayCompletedCards.mockReturnValue({
       data: undefined,
       isLoading: false,
@@ -139,24 +158,6 @@ describe('CompletedCardsPage', () => {
     // Then: 空状態が表示される
     await waitFor(() => {
       expect(screen.getByTestId('empty-state')).toBeInTheDocument();
-    });
-  });
-
-  it('完了カードがある場合: CardListに完了カードが渡される', async () => {
-    // Given: 完了カード2件
-    const completedCard1 = createCard({ id: 'c1' });
-    const completedCard2 = createCard({ id: 'c2' });
-    mockUseTodayCompletedCards.mockReturnValue({
-      data: [completedCard1, completedCard2],
-      isLoading: false,
-    });
-
-    // When: ページをレンダリング
-    await renderPage();
-
-    // Then: CardListに完了カード2件が渡される
-    await waitFor(() => {
-      expect(screen.getByTestId('card-list')).toHaveTextContent('2 cards');
     });
   });
 });

--- a/apps/web/src/app/(main)/cards/completed/__tests__/page.test.tsx
+++ b/apps/web/src/app/(main)/cards/completed/__tests__/page.test.tsx
@@ -4,10 +4,10 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import type { CardWithTags } from '@/types/card';
 
-const mockUseHomeCards = vi.fn();
+const mockUseTodayCompletedCards = vi.fn();
 
-vi.mock('@/hooks/useHomeCards', () => ({
-  useHomeCards: () => mockUseHomeCards(),
+vi.mock('@/hooks/useCards', () => ({
+  useTodayCompletedCards: () => mockUseTodayCompletedCards(),
 }));
 
 vi.mock('@/components/home', () => ({
@@ -49,8 +49,8 @@ function createCard(overrides: Partial<CardWithTags> = {}): CardWithTags {
     schedule: [1, 3, 7, 14, 30, 180],
     currentStep: 0,
     nextReviewAt: null,
-    status: 'new',
-    completedAt: null,
+    status: 'completed',
+    completedAt: '2025-01-01T00:00:00Z',
     createdAt: '2025-01-01T00:00:00Z',
     updatedAt: '2025-01-01T00:00:00Z',
     tags: [],
@@ -81,9 +81,9 @@ describe('CompletedCardsPage', () => {
   });
 
   it('ページヘッダーに「完了」タイトルが表示される', async () => {
-    // Given: データ読み込み完了
-    mockUseHomeCards.mockReturnValue({
-      data: { cards: [], todayStudiedCardIds: [] },
+    // Given: データ読み込み完了（完了カードなし）
+    mockUseTodayCompletedCards.mockReturnValue({
+      data: [],
       isLoading: false,
     });
 
@@ -97,7 +97,7 @@ describe('CompletedCardsPage', () => {
 
   it('読み込み中の場合: スケルトンが表示される', async () => {
     // Given: データ読み込み中
-    mockUseHomeCards.mockReturnValue({
+    mockUseTodayCompletedCards.mockReturnValue({
       data: undefined,
       isLoading: true,
     });
@@ -110,10 +110,9 @@ describe('CompletedCardsPage', () => {
   });
 
   it('完了カードがない場合: 空状態が表示される', async () => {
-    // Given: 完了カードなし（activeカードのみ）
-    const activeCard = createCard({ id: 'a1', status: 'active' });
-    mockUseHomeCards.mockReturnValue({
-      data: { cards: [activeCard], todayStudiedCardIds: [] },
+    // Given: 完了カードなし
+    mockUseTodayCompletedCards.mockReturnValue({
+      data: [],
       isLoading: false,
     });
 
@@ -127,30 +126,10 @@ describe('CompletedCardsPage', () => {
     });
   });
 
-  it('完了カードがある場合: CardListに完了カードのみ渡される', async () => {
-    // Given: 完了カード2件、activeカード1件
-    const completedCard1 = createCard({ id: 'c1', status: 'completed' });
-    const completedCard2 = createCard({ id: 'c2', status: 'completed' });
-    const activeCard = createCard({ id: 'a1', status: 'active' });
-    mockUseHomeCards.mockReturnValue({
-      data: { cards: [completedCard1, completedCard2, activeCard], todayStudiedCardIds: [] },
-      isLoading: false,
-    });
-
-    // When: ページをレンダリング
-    await renderPage();
-
-    // Then: CardListに完了カード2件のみ渡される
-    await waitFor(() => {
-      expect(screen.getByTestId('card-list')).toHaveTextContent('2 cards');
-    });
-  });
-
-  it('newカードは完了カードに含まれない', async () => {
-    // Given: newカードのみ
-    const newCard = createCard({ id: 'n1', status: 'new' });
-    mockUseHomeCards.mockReturnValue({
-      data: { cards: [newCard], todayStudiedCardIds: [] },
+  it('dataがundefinedの場合: 空状態が表示される', async () => {
+    // Given: データがundefined（初期状態）
+    mockUseTodayCompletedCards.mockReturnValue({
+      data: undefined,
       isLoading: false,
     });
 
@@ -160,6 +139,24 @@ describe('CompletedCardsPage', () => {
     // Then: 空状態が表示される
     await waitFor(() => {
       expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+    });
+  });
+
+  it('完了カードがある場合: CardListに完了カードが渡される', async () => {
+    // Given: 完了カード2件
+    const completedCard1 = createCard({ id: 'c1' });
+    const completedCard2 = createCard({ id: 'c2' });
+    mockUseTodayCompletedCards.mockReturnValue({
+      data: [completedCard1, completedCard2],
+      isLoading: false,
+    });
+
+    // When: ページをレンダリング
+    await renderPage();
+
+    // Then: CardListに完了カード2件が渡される
+    await waitFor(() => {
+      expect(screen.getByTestId('card-list')).toHaveTextContent('2 cards');
     });
   });
 });

--- a/apps/web/src/app/(main)/cards/completed/page.tsx
+++ b/apps/web/src/app/(main)/cards/completed/page.tsx
@@ -2,7 +2,7 @@
 
 import { CheckCheck } from 'lucide-react';
 
-import { CardList } from '@/components/home';
+import { CompletedCard } from '@/components/home';
 import { PageHeader } from '@/components/layout/page-header';
 import { EmptyState } from '@/components/ui/empty-state';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -44,7 +44,11 @@ export default function CompletedCardsPage() {
             description="カードを学習して「覚えた」と評価すると、ここに表示されます"
           />
         ) : (
-          <CardList cards={completedCards} />
+          <div className="space-y-4" data-testid="card-list">
+            {completedCards.map((card) => (
+              <CompletedCard key={card.id} card={card} />
+            ))}
+          </div>
         )}
       </div>
     </div>

--- a/apps/web/src/app/(main)/cards/completed/page.tsx
+++ b/apps/web/src/app/(main)/cards/completed/page.tsx
@@ -1,14 +1,12 @@
 'use client';
 
-import { useMemo } from 'react';
-
 import { CheckCheck } from 'lucide-react';
 
 import { CardList } from '@/components/home';
 import { PageHeader } from '@/components/layout/page-header';
 import { EmptyState } from '@/components/ui/empty-state';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useHomeCards } from '@/hooks/useHomeCards';
+import { useTodayCompletedCards } from '@/hooks/useCards';
 
 function CompletedPageSkeleton() {
   return (
@@ -28,12 +26,7 @@ function CompletedPageSkeleton() {
 }
 
 export default function CompletedCardsPage() {
-  const { data, isLoading } = useHomeCards();
-
-  const completedCards = useMemo(() => {
-    if (!data) return [];
-    return data.cards.filter((card) => card.status === 'completed');
-  }, [data]);
+  const { data: completedCards, isLoading } = useTodayCompletedCards();
 
   return (
     <div>
@@ -44,7 +37,7 @@ export default function CompletedCardsPage() {
       <div className="p-4 md:p-6">
         {isLoading ? (
           <CompletedPageSkeleton />
-        ) : completedCards.length === 0 ? (
+        ) : !completedCards || completedCards.length === 0 ? (
           <EmptyState
             icon={<CheckCheck />}
             title="完了済みカードなし"

--- a/apps/web/src/components/home/completed-card.tsx
+++ b/apps/web/src/components/home/completed-card.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { Check } from 'lucide-react';
+import { memo, useCallback, useMemo } from 'react';
+import { toast } from 'sonner';
+
+import { StudyCard } from '@/components/ui/study-card';
+import { TagBadge } from '@/components/ui/tag-badge';
+import { useHomeUpdateCard } from '@/hooks/useHomeCards';
+import type { CardWithTags } from '@/types/card';
+
+function formatCompletedDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  return `${year}/${month}/${day}`;
+}
+
+interface CompletedCardProps {
+  card: CardWithTags;
+}
+
+export const CompletedCard = memo(function CompletedCard({ card }: CompletedCardProps) {
+  const updateCard = useHomeUpdateCard();
+
+  const tags = useMemo(() => {
+    if (card.tags.length === 0) return undefined;
+    return (
+      <>
+        {card.tags.map((tag) => (
+          <TagBadge key={tag.id}>{tag.name}</TagBadge>
+        ))}
+      </>
+    );
+  }, [card.tags]);
+
+  const handleSave = useCallback(
+    async (data: { front?: string; back?: string }) => {
+      try {
+        await updateCard.mutateAsync({ id: card.id, input: data });
+        toast.success('カードを更新しました');
+      } catch {
+        toast.error('カードの更新に失敗しました');
+      }
+    },
+    [card.id, updateCard]
+  );
+
+  return (
+    <div className="bg-card rounded-xl shadow-sm overflow-hidden">
+      <StudyCard
+        answer={card.back}
+        currentStep={card.currentStep}
+        question={card.front}
+        tags={tags}
+        totalSteps={card.schedule.length}
+        onSave={handleSave}
+      />
+      {card.completedAt && (
+        <div className="px-4 py-2 flex items-center justify-end gap-1.5">
+          <Check className="w-3 h-3 text-green-400" />
+          <span className="text-xs text-gray-400">
+            完了: {formatCompletedDate(card.completedAt)}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+});

--- a/apps/web/src/components/home/index.ts
+++ b/apps/web/src/components/home/index.ts
@@ -1,4 +1,5 @@
 export { QuickInputForm } from './quick-input-form';
 export { CardTabs, type CardTabValue } from './card-tabs';
 export { CardList } from './card-list';
+export { CompletedCard } from './completed-card';
 export { HomeStudyCard } from './home-study-card';

--- a/apps/web/src/hooks/useCards.ts
+++ b/apps/web/src/hooks/useCards.ts
@@ -67,6 +67,7 @@ export function useTodayCompletedCards() {
   return useQuery<CardWithTags[]>({
     queryKey: cardKeys.todayCompleted(),
     queryFn: () => getTodayCompletedCards(),
+    refetchOnMount: 'always',
   });
 }
 

--- a/apps/web/src/hooks/useHomeCards.ts
+++ b/apps/web/src/hooks/useHomeCards.ts
@@ -11,6 +11,7 @@ import {
   updateCard,
 } from '@/actions/cards';
 import { submitAssessment } from '@/actions/study';
+import { cardKeys } from '@/hooks/useCards';
 import { homeCardKeys } from '@/lib/query-keys';
 import { DEFAULT_INTERVALS } from '@/types/review-schedule';
 import type {
@@ -262,6 +263,7 @@ export function useHomeSubmitAssessment() {
         );
         return { ...old, cards };
       });
+      qc.invalidateQueries({ queryKey: cardKeys.todayCompleted() });
     },
   });
 }


### PR DESCRIPTION
## Summary

- 完了ページに `CompletedCard` コンポーネントを新規作成し、カード右下に完了日時（例: `完了: 2026/4/2`）を表示
- `getTodayCompletedCards` を `status = 'completed'` のカードのみ返すシンプルな実装に変更（今日学習したカードの混入を排除）
- ホームで「覚えた」評価後に完了ページのキャッシュを invalidate し、遷移時に最新データが表示されるよう修正
- `refetchOnMount: 'always'` で完了ページ遷移のたびに最新取得

## Test plan

- [ ] 完了ページに遷移して、各カード右下に `✓ 完了: YYYY/M/D` が表示されることを確認
- [ ] `status = completed` のカードのみ表示されることを確認（active/new カードが混入しない）
- [ ] ホームで「覚えた」を押した後、完了ページに遷移して新しいカードが表示されることを確認
- [ ] `pnpm test` がパスすることを確認