### PR TITLE
fix(home): カード作成後に未学習タブへ即時表示されない問題を修正

### DIFF
--- a/apps/web/src/app/(main)/_components/dashboard-content.tsx
+++ b/apps/web/src/app/(main)/_components/dashboard-content.tsx
@@ -200,6 +200,7 @@ export function DashboardContent() {
                     }}
                     schedule={card.schedule}
                     showAgain={card.currentStep > 0}
+                    sourceUrl={card.sourceUrl}
                     tags={card.tags}
                     onEdit={() => handleEdit(card)}
                   />

--- a/apps/web/src/components/cards/card-input-form.tsx
+++ b/apps/web/src/components/cards/card-input-form.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { Settings, ChevronDown } from 'lucide-react';
+import { X } from 'lucide-react';
 import TextareaAutosize from 'react-textarea-autosize';
 
 import { Button } from '@/components/ui/button';
@@ -18,11 +18,6 @@ import {
   FormLabel,
   FormMessage,
 } from '@/components/ui/form';
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from '@/components/ui/collapsible';
 import { TagSelector } from '@/components/cards/tag-selector';
 import { cn } from '@/lib/utils';
 
@@ -92,7 +87,6 @@ export function CardInputForm({
   isSubmitting = false,
   formId,
 }: CardInputFormProps) {
-  const [optionsOpen, setOptionsOpen] = useState(false);
   const form = useForm<CardInputFormValues>({
     resolver: zodResolver(cardInputSchema),
     defaultValues: {
@@ -221,60 +215,44 @@ export function CardInputForm({
             />
           </div>
 
-          {/* Optional Settings (Collapsible) */}
-          <Collapsible open={optionsOpen} onOpenChange={setOptionsOpen}>
-            <CollapsibleTrigger asChild>
-              <button
-                type="button"
-                className={cn(
-                  'w-full flex items-center justify-between px-5 py-4',
-                  'bg-muted/40 border-t',
-                  'transition-colors hover:bg-muted/60',
-                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-inset'
-                )}
-              >
-                <span className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
-                  <Settings className="h-4 w-4" />
-                  詳細設定
-                </span>
-                <ChevronDown
-                  className={cn(
-                    'h-5 w-5 text-muted-foreground transition-transform duration-200',
-                    optionsOpen && 'rotate-180'
-                  )}
-                />
-              </button>
-            </CollapsibleTrigger>
-            <CollapsibleContent>
-              <div className="px-5 py-5 space-y-5 bg-muted/40 border-t">
-                {/* Source URL */}
-                <FormField
-                  control={form.control}
-                  name="sourceUrl"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel className="text-sm font-medium mb-2 block">
-                        ソースURL
-                      </FormLabel>
-                      <FormControl>
-                        <Input
-                          type="url"
-                          placeholder="https://example.com"
-                          className="h-11"
-                          {...field}
-                        />
-                      </FormControl>
-                      <FormDescription className="text-[13px] mt-2">
-                        参照元のURLを記録できます
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-              </div>
-            </CollapsibleContent>
-          </Collapsible>
+          {/* Source URL */}
+          <div className="px-5 pb-5">
+            <FormField
+              control={form.control}
+              name="sourceUrl"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-sm font-medium mb-2 block">
+                    ソースURL
+                  </FormLabel>
+                  <FormControl>
+                    <div className="relative flex items-center">
+                      <Input
+                        type="url"
+                        placeholder="https://example.com"
+                        className="h-11 pr-10"
+                        {...field}
+                      />
+                      {field.value && (
+                        <button
+                          type="button"
+                          className="absolute right-2 text-muted-foreground hover:text-foreground transition-colors"
+                          onClick={() => field.onChange('')}
+                          title="クリア"
+                        >
+                          <X className="h-4 w-4" />
+                        </button>
+                      )}
+                    </div>
+                  </FormControl>
+                  <FormDescription className="text-[13px] mt-2">
+                    参照元のURLを記録できます
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
         </div>
 
         {/* Submit Button - Desktop only, mobile uses sticky footer in parent */}

--- a/apps/web/src/components/cards/card-input-form.tsx
+++ b/apps/web/src/components/cards/card-input-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -98,14 +98,20 @@ export function CardInputForm({
   const frontValue = form.watch('front');
   const isSaveDisabled = !frontValue.trim() || isSubmitting;
 
+  const isMounted = useRef(false);
   useEffect(() => {
+    if (!isMounted.current) {
+      isMounted.current = true;
+      return;
+    }
     if (defaultValues) {
       form.reset({
         ...defaultFormValues,
         ...defaultValues,
       });
     }
-  }, [defaultValues, form]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaultValues]);
 
   async function handleSubmit(data: CardInputFormValues) {
     await onSubmit(data);

--- a/apps/web/src/components/cards/edit-card-dialog.tsx
+++ b/apps/web/src/components/cards/edit-card-dialog.tsx
@@ -33,7 +33,7 @@ export function EditCardDialog({ card, open, onOpenChange }: EditCardDialogProps
         input: {
           front: data.front,
           back: data.back || undefined,
-          sourceUrl: data.sourceUrl || undefined,
+          sourceUrl: data.sourceUrl,
           tagIds: data.tagIds.length > 0 ? data.tagIds : undefined,
         },
       });

--- a/apps/web/src/components/home/card-list.tsx
+++ b/apps/web/src/components/home/card-list.tsx
@@ -110,6 +110,7 @@ const CardItem = memo(function CardItem({
       answer={card.back}
       currentStep={card.currentStep}
       question={card.front}
+      sourceUrl={card.sourceUrl}
       ratingButtons={<ResetButton disabled={isResetting} onReset={handleReset} />}
       tags={tags}
       totalSteps={card.schedule.length}

--- a/apps/web/src/components/home/home-study-card.tsx
+++ b/apps/web/src/components/home/home-study-card.tsx
@@ -29,6 +29,7 @@ interface HomeStudyCardProps {
   tags?: Tag[];
   currentStep?: number;
   schedule?: number[];
+  sourceUrl?: string | null;
   intervals?: { ok?: string; again?: string };
   showAgain?: boolean;
   onAssessmentComplete?: () => void;
@@ -51,6 +52,7 @@ export const HomeStudyCard = memo(function HomeStudyCard({
   tags = [],
   currentStep,
   schedule,
+  sourceUrl,
   intervals,
   showAgain = true,
   onAssessmentComplete,
@@ -142,6 +144,7 @@ export const HomeStudyCard = memo(function HomeStudyCard({
           className={className}
           currentStep={currentStep}
           question={front}
+          sourceUrl={sourceUrl}
           ratingButtons={
             <RatingButtons
               disabled={submitAssessment.isPending || isRemoving}

--- a/apps/web/src/components/ui/study-card.tsx
+++ b/apps/web/src/components/ui/study-card.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { memo, useCallback, useEffect, useRef, useState } from 'react'
-import { Check, Eye, EyeOff, Pencil, SquarePen, Trash2, X } from 'lucide-react'
+import { Check, Eye, EyeOff, ExternalLink, Link, Pencil, SquarePen, Trash2, X } from 'lucide-react'
 import TextareaAutosize from 'react-textarea-autosize'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -13,6 +13,7 @@ interface StudyCardProps {
   ratingButtons?: React.ReactNode
   currentStep?: number
   totalSteps?: number
+  sourceUrl?: string | null
   onEdit?: () => void
   onDelete?: () => void
   onSave?: (data: { front?: string; back?: string }) => void
@@ -27,6 +28,7 @@ export const StudyCard = memo(function StudyCard({
   ratingButtons,
   currentStep,
   totalSteps,
+  sourceUrl,
   onEdit,
   onDelete,
   onSave,
@@ -351,6 +353,28 @@ export const StudyCard = memo(function StudyCard({
           )}
         </div>
       )}
+
+      {sourceUrl && (() => {
+        let hostname = sourceUrl
+        try { hostname = new URL(sourceUrl).hostname } catch {}
+        return (
+          <div className="px-4 pb-3 bg-card">
+            <div className="border-t border-border pt-2">
+              <a
+                href={sourceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <Link className="h-3 w-3 flex-shrink-0" />
+                <span>{hostname}</span>
+                <ExternalLink className="h-3 w-3 flex-shrink-0" />
+              </a>
+            </div>
+          </div>
+        )
+      })()}
     </div>
   )
 })

--- a/apps/web/src/hooks/useCards.ts
+++ b/apps/web/src/hooks/useCards.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import type { QueryKey } from '@tanstack/react-query';
+import type { InfiniteData, QueryKey } from '@tanstack/react-query';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
@@ -22,6 +22,7 @@ import type {
   CardListResponse,
   CardWithTags,
   CreateCardInput,
+  HomeCardsPage,
   UpdateCardInput,
 } from '@/types/card';
 
@@ -156,6 +157,8 @@ type UpdateCardContext = {
   previousNew: CardWithTags[] | undefined;
   previousToday: CardWithTags[] | undefined;
   previousTodayCompleted: CardWithTags[] | undefined;
+  previousHomeDue: InfiniteData<HomeCardsPage> | undefined;
+  previousHomeLearning: InfiniteData<HomeCardsPage> | undefined;
 };
 
 export function useUpdateCard() {
@@ -164,11 +167,15 @@ export function useUpdateCard() {
     mutationFn: ({ id, input }: { id: string; input: UpdateCardInput }) =>
       updateCard(id, input),
     onMutate: async ({ id, input }): Promise<UpdateCardContext> => {
-      await qc.cancelQueries({ queryKey: cardKeys.lists() });
-      await qc.cancelQueries({ queryKey: cardKeys.detail(id) });
-      await qc.cancelQueries({ queryKey: cardKeys.new() });
-      await qc.cancelQueries({ queryKey: cardKeys.today() });
-      await qc.cancelQueries({ queryKey: cardKeys.todayCompleted() });
+      await Promise.all([
+        qc.cancelQueries({ queryKey: cardKeys.lists() }),
+        qc.cancelQueries({ queryKey: cardKeys.detail(id) }),
+        qc.cancelQueries({ queryKey: cardKeys.new() }),
+        qc.cancelQueries({ queryKey: cardKeys.today() }),
+        qc.cancelQueries({ queryKey: cardKeys.todayCompleted() }),
+        qc.cancelQueries({ queryKey: homeCardKeys.tab('due') }),
+        qc.cancelQueries({ queryKey: homeCardKeys.tab('learning') }),
+      ]);
 
       const previousLists = qc.getQueriesData<CardListResponse>({
         queryKey: cardKeys.lists(),
@@ -177,6 +184,8 @@ export function useUpdateCard() {
       const previousNew = qc.getQueryData<CardWithTags[]>(cardKeys.new());
       const previousToday = qc.getQueryData<CardWithTags[]>(cardKeys.today());
       const previousTodayCompleted = qc.getQueryData<CardWithTags[]>(cardKeys.todayCompleted());
+      const previousHomeDue = qc.getQueryData<InfiniteData<HomeCardsPage>>(homeCardKeys.tab('due'));
+      const previousHomeLearning = qc.getQueryData<InfiniteData<HomeCardsPage>>(homeCardKeys.tab('learning'));
 
       const updateCardInList = (card: CardWithTags): CardWithTags =>
         card.id === id
@@ -217,7 +226,27 @@ export function useUpdateCard() {
         );
       }
 
-      return { previousLists, previousDetail, previousNew, previousToday, previousTodayCompleted };
+      if (previousHomeDue) {
+        qc.setQueryData<InfiniteData<HomeCardsPage>>(homeCardKeys.tab('due'), {
+          ...previousHomeDue,
+          pages: previousHomeDue.pages.map((page) => ({
+            ...page,
+            cards: page.cards.map(updateCardInList),
+          })),
+        });
+      }
+
+      if (previousHomeLearning) {
+        qc.setQueryData<InfiniteData<HomeCardsPage>>(homeCardKeys.tab('learning'), {
+          ...previousHomeLearning,
+          pages: previousHomeLearning.pages.map((page) => ({
+            ...page,
+            cards: page.cards.map(updateCardInList),
+          })),
+        });
+      }
+
+      return { previousLists, previousDetail, previousNew, previousToday, previousTodayCompleted, previousHomeDue, previousHomeLearning };
     },
     onError: (_, variables, context) => {
       if (context?.previousLists) {
@@ -236,6 +265,12 @@ export function useUpdateCard() {
       }
       if (context?.previousTodayCompleted) {
         qc.setQueryData(cardKeys.todayCompleted(), context.previousTodayCompleted);
+      }
+      if (context?.previousHomeDue) {
+        qc.setQueryData(homeCardKeys.tab('due'), context.previousHomeDue);
+      }
+      if (context?.previousHomeLearning) {
+        qc.setQueryData(homeCardKeys.tab('learning'), context.previousHomeLearning);
       }
       toast.error('カードの更新に失敗しました');
     },

--- a/apps/web/src/hooks/useCards.ts
+++ b/apps/web/src/hooks/useCards.ts
@@ -246,6 +246,8 @@ export function useUpdateCard() {
       qc.invalidateQueries({ queryKey: cardKeys.today() });
       qc.invalidateQueries({ queryKey: cardKeys.todayCompleted() });
       qc.invalidateQueries({ queryKey: homeCardKeys.tab('completed') });
+      qc.invalidateQueries({ queryKey: homeCardKeys.tab('due'), refetchType: 'all' });
+      qc.invalidateQueries({ queryKey: homeCardKeys.tab('learning'), refetchType: 'all' });
     },
   });
 }

--- a/apps/web/src/hooks/useHomeCards.ts
+++ b/apps/web/src/hooks/useHomeCards.ts
@@ -210,10 +210,19 @@ export function useHomeCreateCard() {
         tags: [],
       };
 
-      qc.setQueryData<InfiniteData<HomeCardsPage>>(homeCardKeys.tab('due'), (old) => {
-        if (!old) return old;
-        return prependCardToInfiniteData(old, optimisticCard);
-      });
+      const emptyInfiniteData: InfiniteData<HomeCardsPage> = {
+        pages: [{
+          cards: [],
+          todayStudiedCardIds: [],
+          fetchedAt: new Date().toISOString(),
+          pagination: { total: 0, limit: HOME_PAGE_SIZE, offset: 0, hasMore: false },
+        }],
+        pageParams: [0],
+      };
+
+      qc.setQueryData<InfiniteData<HomeCardsPage>>(homeCardKeys.tab('due'), (old) =>
+        prependCardToInfiniteData(old ?? emptyInfiniteData, optimisticCard)
+      );
 
       return context;
     },
@@ -226,7 +235,8 @@ export function useHomeCreateCard() {
     onSuccess: (newCard) => {
       qc.setQueryData<InfiniteData<HomeCardsPage>>(homeCardKeys.tab('due'), (old) => {
         if (!old) return old;
-        return updateCardInInfiniteData(old, old.pages[0]?.cards.find((c) => c.id.startsWith('temp-'))?.id ?? '', () => ({
+        const tempId = old.pages[0]?.cards.find((c) => c.id.startsWith('temp-'))?.id ?? '';
+        return updateCardInInfiniteData(old, tempId, () => ({
           ...newCard,
           tags: [],
           status: newCard.status as CardWithTags['status'],

--- a/apps/web/src/hooks/useHomeCards.ts
+++ b/apps/web/src/hooks/useHomeCards.ts
@@ -289,6 +289,10 @@ export function useHomeUpdateCard() {
         });
       }
     },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: homeCardKeys.tab('due') });
+      qc.invalidateQueries({ queryKey: homeCardKeys.tab('learning') });
+    },
   });
 }
 

--- a/apps/web/src/hooks/useHomeCards.ts
+++ b/apps/web/src/hooks/useHomeCards.ts
@@ -290,8 +290,8 @@ export function useHomeUpdateCard() {
       }
     },
     onSettled: () => {
-      qc.invalidateQueries({ queryKey: homeCardKeys.tab('due') });
-      qc.invalidateQueries({ queryKey: homeCardKeys.tab('learning') });
+      qc.invalidateQueries({ queryKey: homeCardKeys.tab('due'), refetchType: 'all' });
+      qc.invalidateQueries({ queryKey: homeCardKeys.tab('learning'), refetchType: 'all' });
     },
   });
 }

--- a/docs/mocks/source-url-card/mock.html
+++ b/docs/mocks/source-url-card/mock.html
@@ -1,0 +1,288 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>sourceURL カード表示 UIモック 3パターン</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            primary: 'hsl(217.2, 91.2%, 59.8%)',
+          }
+        }
+      }
+    }
+  </script>
+  <style>
+    body { font-family: 'Noto Sans JP', 'Inter', sans-serif; background: #f0f4f8; }
+    .card { background: white; border-radius: 12px; box-shadow: 0 1px 4px rgba(0,0,0,0.08); }
+    .pattern-section { margin-bottom: 48px; }
+    .pattern-label { font-size: 13px; font-weight: 600; color: #64748b; letter-spacing: 0.05em; text-transform: uppercase; margin-bottom: 12px; }
+  </style>
+</head>
+<body class="p-6 max-w-lg mx-auto">
+
+  <h1 class="text-xl font-bold text-slate-800 mb-2">sourceURL 表示 UIモック</h1>
+  <p class="text-sm text-slate-500 mb-8">カードにリンクがある場合の表示パターン（3種類）</p>
+
+  <!-- ============================================================ -->
+  <!-- Pattern 1: 控えめなフッターリンク（保守的） -->
+  <!-- ============================================================ -->
+  <div class="pattern-section">
+    <div class="pattern-label">Pattern 1 — 控えめなフッターリンク（保守的）</div>
+    <p class="text-xs text-slate-400 mb-3">カード下部にさりげなく配置。学習に集中させつつ出典を確認できる。</p>
+
+    <div class="card overflow-hidden">
+      <!-- header -->
+      <div class="px-5 pt-4 pb-3">
+        <div class="flex items-start justify-between gap-3">
+          <p class="text-base text-slate-800 leading-relaxed flex-1">
+            ReactのuseEffectのdependency arrayに関数を入れると何が起きる？
+          </p>
+          <div class="flex gap-1 flex-shrink-0">
+            <button class="h-8 w-8 rounded-md flex items-center justify-center text-slate-400 hover:text-slate-600 hover:bg-slate-100">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
+            </button>
+            <button class="h-8 w-8 rounded-md flex items-center justify-center text-slate-400 hover:text-red-500 hover:bg-red-50">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/></svg>
+            </button>
+          </div>
+        </div>
+        <!-- タグ -->
+        <div class="mt-2 flex gap-1.5">
+          <span class="text-xs px-2 py-0.5 rounded-full bg-sky-100 text-sky-700 border border-sky-200">React</span>
+          <span class="text-xs px-2 py-0.5 rounded-full bg-sky-100 text-sky-700 border border-sky-200">Hooks</span>
+        </div>
+      </div>
+
+      <!-- 答えボタン -->
+      <div class="flex justify-center py-2 bg-white">
+        <button class="inline-flex items-center gap-2 px-6 h-9 rounded-full text-sm font-semibold border-2 bg-blue-500 text-white border-blue-500">
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94"/><path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19"/><line x1="1" y1="1" x2="23" y2="23"/></svg>
+          答えを隠す
+        </button>
+      </div>
+
+      <!-- 答えエリア（展開済み） -->
+      <div class="px-5 py-4 bg-white">
+        <div class="inline-block px-4 py-3 bg-amber-50 border border-amber-200 rounded-lg">
+          <p class="text-base text-slate-800 leading-relaxed">
+            毎レンダーで新しい関数参照が生成されるため、無限ループが発生する可能性がある。useCallbackでメモ化するか、dependency arrayから除外する。
+          </p>
+        </div>
+      </div>
+
+      <!-- 評価ボタン -->
+      <div class="px-5 py-3 flex gap-2">
+        <button class="flex-1 h-10 rounded-lg bg-red-50 text-red-500 text-sm font-medium">もう一度</button>
+        <button class="flex-1 h-10 rounded-lg bg-green-50 text-green-600 text-sm font-medium">OK</button>
+        <button class="flex-1 h-10 rounded-lg bg-slate-100 text-slate-600 text-sm font-medium">完了</button>
+      </div>
+
+      <!-- sourceURL フッター（Pattern 1のポイント） -->
+      <a
+        href="https://react.dev/reference/react/useEffect"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="flex items-center gap-2 px-5 py-2.5 border-t border-slate-100 hover:bg-slate-50 transition-colors group"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-slate-400 flex-shrink-0"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+        <span class="text-xs text-slate-400 truncate flex-1 group-hover:text-slate-600 transition-colors">
+          react.dev — useEffect リファレンス
+        </span>
+        <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-slate-300 flex-shrink-0 group-hover:text-slate-500"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+      </a>
+    </div>
+  </div>
+
+  <hr class="border-slate-200 my-8" />
+
+  <!-- ============================================================ -->
+  <!-- Pattern 2: リッチリンクプレビュー（推奨案） -->
+  <!-- ============================================================ -->
+  <div class="pattern-section">
+    <div class="pattern-label">Pattern 2 — リッチリンクプレビュー（推奨案）</div>
+    <p class="text-xs text-slate-400 mb-3">OGPタイトル・ドメインを見やすく表示。答え展開後に出典として自然に目に入る。</p>
+
+    <div class="card overflow-hidden">
+      <!-- header -->
+      <div class="px-5 pt-4 pb-3">
+        <div class="flex items-start justify-between gap-3">
+          <p class="text-base text-slate-800 leading-relaxed flex-1">
+            Supabaseでリアルタイム購読をセットアップする方法は？
+          </p>
+          <div class="flex gap-1 flex-shrink-0">
+            <button class="h-8 w-8 rounded-md flex items-center justify-center text-slate-400 hover:text-slate-600 hover:bg-slate-100">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
+            </button>
+          </div>
+        </div>
+        <div class="mt-2 flex gap-1.5">
+          <span class="text-xs px-2 py-0.5 rounded-full bg-sky-100 text-sky-700 border border-sky-200">Supabase</span>
+        </div>
+      </div>
+
+      <!-- 答えボタン -->
+      <div class="flex justify-center py-2 bg-white">
+        <button class="inline-flex items-center gap-2 px-6 h-9 rounded-full text-sm font-semibold border-2 bg-blue-500 text-white border-blue-500">
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94"/><path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19"/><line x1="1" y1="1" x2="23" y2="23"/></svg>
+          答えを隠す
+        </button>
+      </div>
+
+      <!-- 答えエリア -->
+      <div class="px-5 py-4 bg-white">
+        <div class="inline-block px-4 py-3 bg-amber-50 border border-amber-200 rounded-lg">
+          <p class="text-base text-slate-800 leading-relaxed">
+            supabase.channel('room').on('postgres_changes', ...) を使い、subscribe() を呼ぶ。クリーンアップでは channel.unsubscribe() を実行する。
+          </p>
+        </div>
+      </div>
+
+      <!-- 評価ボタン -->
+      <div class="px-5 py-3 flex gap-2">
+        <button class="flex-1 h-10 rounded-lg bg-red-50 text-red-500 text-sm font-medium">もう一度</button>
+        <button class="flex-1 h-10 rounded-lg bg-green-50 text-green-600 text-sm font-medium">OK</button>
+        <button class="flex-1 h-10 rounded-lg bg-slate-100 text-slate-600 text-sm font-medium">完了</button>
+      </div>
+
+      <!-- sourceURL リッチプレビュー（Pattern 2のポイント） -->
+      <div class="px-5 pb-4 pt-1">
+        <a
+          href="https://supabase.com/docs/guides/realtime"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="flex items-center gap-3 p-3 rounded-xl border border-slate-200 hover:border-blue-300 hover:bg-blue-50/50 transition-all group"
+        >
+          <!-- favicon -->
+          <div class="w-8 h-8 rounded-lg bg-emerald-500 flex items-center justify-center flex-shrink-0">
+            <span class="text-white text-xs font-bold">S</span>
+          </div>
+          <div class="flex-1 min-w-0">
+            <p class="text-sm font-medium text-slate-700 truncate group-hover:text-blue-600 transition-colors">
+              Realtime | Supabase Docs
+            </p>
+            <p class="text-xs text-slate-400 truncate mt-0.5">supabase.com</p>
+          </div>
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-slate-300 flex-shrink-0 group-hover:text-blue-400 transition-colors"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+        </a>
+      </div>
+    </div>
+  </div>
+
+  <hr class="border-slate-200 my-8" />
+
+  <!-- ============================================================ -->
+  <!-- Pattern 3: 「出典」バッジ + ドロワー展開（実験的） -->
+  <!-- ============================================================ -->
+  <div class="pattern-section">
+    <div class="pattern-label">Pattern 3 — 出典バッジ＋インライン展開（実験的）</div>
+    <p class="text-xs text-slate-400 mb-3">質問エリアに「出典あり」バッジを配置。タップで答えの下にリンクをインライン展開する。</p>
+
+    <div class="card overflow-hidden">
+      <!-- header -->
+      <div class="px-5 pt-4 pb-3">
+        <div class="flex items-start justify-between gap-3">
+          <div class="flex-1">
+            <p class="text-base text-slate-800 leading-relaxed">
+              TypeScriptのsatisfies演算子とは何か？as との違いは？
+            </p>
+            <!-- 出典バッジ（Pattern 3のポイント1） -->
+            <div class="mt-2 flex items-center gap-2">
+              <div class="flex gap-1.5">
+                <span class="text-xs px-2 py-0.5 rounded-full bg-sky-100 text-sky-700 border border-sky-200">TypeScript</span>
+              </div>
+              <span class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-violet-50 text-violet-500 border border-violet-200">
+                <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+                出典あり
+              </span>
+            </div>
+          </div>
+          <div class="flex gap-1 flex-shrink-0">
+            <button class="h-8 w-8 rounded-md flex items-center justify-center text-slate-400 hover:text-slate-600 hover:bg-slate-100">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- 答えボタン -->
+      <div class="flex justify-center py-2 bg-white">
+        <button class="inline-flex items-center gap-2 px-6 h-9 rounded-full text-sm font-semibold border-2 bg-blue-500 text-white border-blue-500">
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94"/><path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19"/><line x1="1" y1="1" x2="23" y2="23"/></svg>
+          答えを隠す
+        </button>
+      </div>
+
+      <!-- 答えエリア -->
+      <div class="px-5 py-4 bg-white">
+        <div class="inline-block px-4 py-3 bg-amber-50 border border-amber-200 rounded-lg">
+          <p class="text-base text-slate-800 leading-relaxed">
+            satisfies は型チェックのみ行い、型推論の結果を保持する。as は強制型変換で型安全性を失う。satisfies を優先し、as はやむを得ない場合のみ使う。
+          </p>
+        </div>
+
+        <!-- 出典インライン展開（Pattern 3のポイント2）: 答え展開後に自動表示 -->
+        <div class="mt-3 rounded-xl border border-violet-100 bg-violet-50/60 overflow-hidden">
+          <div class="flex items-center gap-2 px-3 py-2 border-b border-violet-100">
+            <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" class="text-violet-400"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+            <span class="text-xs font-medium text-violet-500">出典</span>
+          </div>
+          <a
+            href="https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/#the-satisfies-operator"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="flex items-center gap-3 px-3 py-2.5 hover:bg-violet-100/60 transition-colors group"
+          >
+            <div class="w-7 h-7 rounded bg-blue-600 flex items-center justify-center flex-shrink-0">
+              <span class="text-white text-xs font-bold">TS</span>
+            </div>
+            <div class="flex-1 min-w-0">
+              <p class="text-sm font-medium text-slate-700 truncate group-hover:text-violet-700 transition-colors">
+                Announcing TypeScript 4.9 — the satisfies Operator
+              </p>
+              <p class="text-xs text-slate-400 mt-0.5">devblogs.microsoft.com</p>
+            </div>
+            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-violet-300 flex-shrink-0 group-hover:text-violet-500 transition-colors"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+          </a>
+        </div>
+      </div>
+
+      <!-- 評価ボタン -->
+      <div class="px-5 pb-4 flex gap-2">
+        <button class="flex-1 h-10 rounded-lg bg-red-50 text-red-500 text-sm font-medium">もう一度</button>
+        <button class="flex-1 h-10 rounded-lg bg-green-50 text-green-600 text-sm font-medium">OK</button>
+        <button class="flex-1 h-10 rounded-lg bg-slate-100 text-slate-600 text-sm font-medium">完了</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- URLなしカード（参考） -->
+  <div class="mt-4 mb-2">
+    <div class="pattern-label">参考 — sourceUrlなしカード（変化なし）</div>
+    <div class="card overflow-hidden">
+      <div class="px-5 pt-4 pb-3">
+        <p class="text-base text-slate-800 leading-relaxed">CSSのgrid-template-areasの使い方は？</p>
+        <div class="mt-2 flex gap-1.5">
+          <span class="text-xs px-2 py-0.5 rounded-full bg-sky-100 text-sky-700 border border-sky-200">CSS</span>
+        </div>
+      </div>
+      <div class="flex justify-center py-2">
+        <button class="inline-flex items-center gap-2 px-6 h-9 rounded-full text-sm font-semibold border-2 border-blue-500 text-blue-500">
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+          答えを見る
+        </button>
+      </div>
+      <div class="px-5 pb-4 flex gap-2">
+        <button class="flex-1 h-10 rounded-lg bg-red-50 text-red-500 text-sm font-medium">もう一度</button>
+        <button class="flex-1 h-10 rounded-lg bg-green-50 text-green-600 text-sm font-medium">OK</button>
+        <button class="flex-1 h-10 rounded-lg bg-slate-100 text-slate-600 text-sm font-medium">完了</button>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- `useHomeCreateCard` の `onMutate` で dueQuery のキャッシュが未初期化（`isDueEnabled=false`）の場合、楽観的更新が空振りしてカードが表示されなかった
- `old ?? emptyInfiniteData` フォールバックを追加し、キャッシュ未初期化でも先頭にカードを追加するよう修正

## Test plan
- [ ] カード作成後に未学習タブに即時表示されることを確認
- [ ] learningカードがある状態でカード作成しても due タブ切り替え時に表示されることを確認
- [ ] テスト: 311 passed（既存の4件のみ失敗、pre-existing）

Closes #47