### PR TITLE
fix(api): include source_url in cards POST and PATCH route handlers

### DIFF
--- a/apps/web/src/__tests__/validations/card.test.ts
+++ b/apps/web/src/__tests__/validations/card.test.ts
@@ -12,6 +12,7 @@ describe('cardSchema', () => {
     userId: '123e4567-e89b-12d3-a456-426614174001',
     front: '表面のテキスト',
     back: '裏面のテキスト',
+    sourceUrl: null,
     schedule: [1, 3, 7, 14, 30, 180],
     currentStep: 3,
     nextReviewAt: '2024-01-15T00:00:00.000Z',

--- a/apps/web/src/app/api/cards/[id]/route.ts
+++ b/apps/web/src/app/api/cards/[id]/route.ts
@@ -199,7 +199,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Params }
       );
     }
 
-    const { front, back, tagIds } = validationResult.data;
+    const { front, back, tagIds, sourceUrl } = validationResult.data;
 
     const { data: existingCard, error: existingError } = await supabase
       .from('cards')
@@ -223,6 +223,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Params }
     const updateData: Partial<CardRow> = {};
     if (front !== undefined) updateData.front = front;
     if (back !== undefined) updateData.back = back;
+    if (sourceUrl !== undefined) updateData.source_url = sourceUrl || null;
 
     if (Object.keys(updateData).length > 0) {
       updateData.updated_at = new Date().toISOString();

--- a/apps/web/src/app/api/cards/route.ts
+++ b/apps/web/src/app/api/cards/route.ts
@@ -279,7 +279,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { front, back, tagIds } = validationResult.data;
+    const { front, back, tagIds, sourceUrl } = validationResult.data;
 
     const { data: cardData, error: cardError } = await supabase
       .from('cards')
@@ -287,6 +287,7 @@ export async function POST(request: NextRequest) {
         user_id: user.id,
         front,
         back,
+        source_url: sourceUrl || null,
         schedule: [1, 3, 7, 14, 30, 90],
         current_step: 0,
         next_review_at: null,


### PR DESCRIPTION
## 概要
PR #44 (source_url追加) のコードレビューで発見した HIGH 問題2件を修正。

- `POST /api/cards`: source_url が insert に含まれておらず、モバイルクライアントからの入力が無視されていた
- `PATCH /api/cards/[id]`: source_url が updateData に含まれておらず、モバイルクライアントから更新できなかった
- cardSchema テストの validCard fixture に sourceUrl: null を追加（4件の失敗テストを修正）

## コミット
- 009bb15 fix(api): include source_url in cards POST and PATCH route handlers

## 変更ファイル
- apps/web/src/app/api/cards/route.ts
- apps/web/src/app/api/cards/[id]/route.ts
- apps/web/src/__tests__/validations/card.test.ts

Closes #49