### PR TITLE
chore: add .claude/worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ e2e/.auth/
 
 # Claude
 .claude/settings.local.json
+.claude/worktrees/
 .mcp.json
 
 # Plans


### PR DESCRIPTION
## Summary
- `.claude/worktrees/` を `.gitignore` に追加
- worktreeはClaude Codeの一時作業ディレクトリであり、リポジトリに含める必要がない
- 現在developブランチに254ファイルのworktree残骸がステージングされており、マージ後に `git rm --cached` で除外する

## 次のステップ
マージ後、developブランチで以下を実行:
```bash
git rm -r --cached .claude/worktrees/
git commit -m "chore: remove tracked worktree files"
```