### PR TITLE
fix: カード編集ダイアログ保存時のちらつきを修正

### DIFF
--- a/apps/web/src/components/cards/edit-card-dialog.tsx
+++ b/apps/web/src/components/cards/edit-card-dialog.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useMemo } from 'react';
 import { Check, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 
@@ -44,14 +45,19 @@ export function EditCardDialog({ card, open, onOpenChange }: EditCardDialogProps
     }
   };
 
-  const defaultValues: Partial<CardInputFormValues> | undefined = card
-    ? {
-        front: card.front,
-        back: card.back || '',
-        sourceUrl: card.sourceUrl || '',
-        tagIds: card.tags.map((tag) => tag.id),
-      }
-    : undefined;
+  const defaultValues = useMemo<Partial<CardInputFormValues> | undefined>(
+    () =>
+      card
+        ? {
+            front: card.front,
+            back: card.back || '',
+            sourceUrl: card.sourceUrl || '',
+            tagIds: card.tags.map((tag) => tag.id),
+          }
+        : undefined,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [card?.id, card?.front, card?.back, card?.sourceUrl, card?.tags]
+  );
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>


### PR DESCRIPTION
## 概要

カード編集ダイアログで保存ボタンを押した瞬間に、編集前の値が一瞬表示されるちらつきバグを修正。

## 原因

`EditCardDialog` 内で `defaultValues` オブジェクトがレンダリングのたびに新しい参照で生成されていた。
`CardInputForm` の `useEffect` がその参照変化を「データが変わった」と誤検知し、`form.reset()` を実行してフォームを元の値に戻してしまっていた。

## 修正

`defaultValues` を `useMemo` でメモ化し、`card.front` / `card.back` / `card.sourceUrl` / `card.tags` の実値が変わった時だけ新オブジェクトを生成するよう変更。

```ts
// Before: 毎レンダリングで新しいオブジェクト参照を生成
const defaultValues = card ? { front: card.front, ... } : undefined;

// After: 実値が変わった時だけ新しいオブジェクトを生成
const defaultValues = useMemo(
  () => card ? { front: card.front, ... } : undefined,
  [card?.id, card?.front, card?.back, card?.sourceUrl, card?.tags]
);
```

## 変更ファイル

- `apps/web/src/components/cards/edit-card-dialog.tsx`